### PR TITLE
Custom linking hack

### DIFF
--- a/_data/config-metadata.csv
+++ b/_data/config-metadata.csv
@@ -3,7 +3,7 @@ title,Title,
 creator,Creator,
 date,Date Created,
 description,Description,
-subject,Keywords,true
+subject,Keywords,,true
 location,Location
 latitude,Latitude
 longitude,Longitude

--- a/_includes/custom/md-browse-link.html
+++ b/_includes/custom/md-browse-link.html
@@ -1,0 +1,19 @@
+{% comment %}
+
+    Add a browse link styled as a button. Value may be a markdown link
+    Parameters:
+        - value: (string)
+        - class: (string) CSS classes
+
+{% endcomment %}
+
+{% assign href = include.value | strip | url_param_escape | prepend: '/browse.html#' | relative_url %}
+
+{% if include.value | strip | slice: 0 == "[" and include.value | strip | slice:-1 == ")" and include.value | strip | split: "](" | length == 2 %}
+    {% comment %} ### Markdown link ### {% endcomment %}
+    {% assign parts = include.value | strip | split: "](" %}
+    {% assign label = parts[0] | remove: "[" %}
+    <a class="{{ include.class }}" href="{{ href }}">{{ label }}</a>
+{% else %}
+    <a class="{{ include.class }}" href="{{ href }}">{{ include.value }}</a>
+{% endif %}

--- a/_includes/custom/md-external-link.html
+++ b/_includes/custom/md-external-link.html
@@ -1,0 +1,22 @@
+{% comment %}
+
+    Add a link styled as a button. Value may be a Markdown formatted link
+    Parameters:
+        - value: (string)
+        - external: (boolean) external links?
+
+{% endcomment %}
+
+{% if include.value | strip | slice: 0 == "[" and include.value | strip | slice:-1 == ")" and include.value | strip | split: "](" | length == 2 %}
+    {% comment %} ### Markdown link ### {% endcomment %}
+    {% assign parts = include.value | strip | split: "](" %}
+    {% assign label = parts[0] | remove: "[" %}
+    {% assign href = parts[1] | remove: ")" %}
+    <a class="btn btn-info" href="{{ href }}" target="_blank" rel="noopener">
+        {{ label }} {% if include.external %}{% include feature/icon.html icon="box-arrow-up-right" label="Open in new tab" %}{% endif %}
+    </a>
+{% else %}
+    <a class="d-block" href="{{ include.value }}" target="_blank" rel="noopener">
+        {{ include.value }} {% if include.external %}{% include feature/icon.html icon="box-arrow-up-right" label="Open in new tab" %}{% endif %}
+    </a>
+{% endif %}

--- a/_includes/custom/multivalue-external-links.html
+++ b/_includes/custom/multivalue-external-links.html
@@ -1,0 +1,20 @@
+{% comment %}
+
+    Adds zero or more links, styled as buttons
+    Parameters:
+        - value: (string) may include multiple delimited values
+        - delimiter: (string) Optional. Default: ";"
+        - external: (boolean) external links?
+
+{% endcomment %}
+
+{% assign delimiter = include.delimiter %}
+{% unless delimiter %}
+    {% assign delimiter = ";" %}
+{% endunless %}
+
+{% assign values = include.value | split: delimiter %}
+
+{% for value in values %}
+    {% include custom/md-external-link.html value=value external=include.external %}
+{% endfor %}

--- a/_includes/index/featured-terms.html
+++ b/_includes/index/featured-terms.html
@@ -46,7 +46,10 @@
         {% if include.title %}<h2 class="card-title h5">{{ include.title }}</h2>{% endif %}
         <p class="card-text">
             {% for s in topTerms %}
-            <a class="btn btn-sm btn-{{ include.btn-color | default: 'primary' }} m-1" href="{{ s | strip | url_param_escape | prepend: '/browse.html#' | relative_url }}">{{ s | strip }}</a>{% endfor %}
+                {% assign color = include.btn-color | default: 'primary' %}
+                {% assign classes = "btn btn-sm btn-" | append: color | append: " m-1" %}
+                {% include custom/md-browse-link.html value=s class=classes %}
+            {% endfor %}
         </p>
     </div>
 </div>

--- a/_includes/item/metadata.html
+++ b/_includes/item/metadata.html
@@ -11,12 +11,13 @@
         <dt class="field">{{ f.display_name }}:</dt>
         <dd class="field-value">
             {% if f.browse_link == "true" %}
-            {% assign topics = page[f.field] | split: ";" %}
-            {% for t in topics %}
-            <a class="me-3" href="{{ t | strip | url_param_escape | prepend: '/browse.html#' | relative_url }}">{{ t | strip }}</a>
-            {% endfor %}
+                {% assign topics = page[f.field] | split: ";" %}
+                {% for t in topics %}
+                    <a class="me-3" href="{{ t | strip | url_param_escape | prepend: '/browse.html#' | relative_url }}">{{ t | strip }}</a>
+                {% endfor %}
             {% elsif f.external_link == "true" %}
-            <a href="{{ page[f.field] }}" target="_blank" rel="noopener">{{ page[f.field] }}</a>
+                {% assign val = page[f.field] %}
+                {% include custom/multivalue-external-links.html value=val external="true" %}
             {% else %}
             {{ page[f.field] | replace: '""','"' }}{% endif %}
         </dd>

--- a/_includes/js/browse-js.html
+++ b/_includes/js/browse-js.html
@@ -59,7 +59,16 @@ function makeCard(obj) {
     var btns = obj[{{ f.field | jsonify }}].split(";");
     for (var i = 0, len = btns.length; i < len; i++) {
         if(btns[i] != "") {
-        card += '<a class="btn btn-sm btn-secondary m-1 text-wrap" href="{{ page.url | relative_url }}#' + encodeURIComponent(btns[i].trim()) + '">' + btns[i].trim() + '</a>';
+        // TODO: Default behavior
+        // card += '<a class="btn btn-sm btn-secondary m-1 text-wrap" href="{{ page.url | relative_url }}#' 
+        //     + encodeURIComponent(btns[i].trim()) + '">' 
+        //     + btns[i].trim() + '</a>';
+          let label = btns[i].trim();
+          const href = `{{ page.url | relative_url }}#${encodeURIComponent(label)}`;
+          if (isMarkdown(label)) {
+            label = label.slice(1, label.indexOf("]("));
+          }
+          card += `<a class="btn btn-sm btn-secondary m-1 text-wrap" href="${href}">${label}</a>`;
         }
     }
     {% else %}
@@ -81,6 +90,12 @@ function makeCard(obj) {
     card += '</div></div></div>';
     // send back big string
     return card;
+}
+
+function isMarkdown(value) {
+    return value.startsWith('[')
+        && value.endsWith(')')
+        && value.includes('](');
 }
 
 /* filter items function */

--- a/_layouts/home-infographic.html
+++ b/_layouts/home-infographic.html
@@ -20,8 +20,10 @@ layout: page
 
     {% include index/featured-terms.html field="subject" title="Keywords" btn-color="primary" %}
 
-    {% include index/featured-terms.html field="location" title="Biographies" btn-color="outline-secondary" %}
-    
+    {% comment %}
+      {% include index/featured-terms.html field="location" title="Biographies" btn-color="outline-secondary" %}
+    {% endcomment %}
+
     {% comment %}
       {% include index/objects.html %}
     {% endcomment %}


### PR DESCRIPTION
# Changes

- `Subject` (aka Keywords) changed from `browse_link` to `external_link`
- Add custom link components that should use label and URL from a Markdown link
  - Note: I couldn't directly use `{{ value | markdownify }}` for the links because they were all surrounded by `<p>` tags and I would have had much less control of the styling
- Used the custom markdown buttons in:
  - Home page: featured terms
  - Browse pages: browse term buttons
  - Stories pages: External links to documents, keywords
- Comment out the "Biographies" section on homepage
  - This section provides navigation based on `locations` data, of which we currently have none
